### PR TITLE
Parallel: use sync map for the stateObjects in parallel

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2105,17 +2105,10 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 		if parent == nil {
 			parent = bc.GetHeader(block.ParentHash(), block.NumberU64()-1)
 		}
-		var statedb *state.StateDB
-		if ParallelTxMode {
-			statedb, err = state.NewBaseSlotDB(parent.Root, bc.stateCache, bc.snaps)
-			if err != nil {
-				return it.index, err
-			}
-		} else {
-			statedb, err = state.New(parent.Root, bc.stateCache, bc.snaps)
-			if err != nil {
-				return it.index, err
-			}
+
+		statedb, err := state.New(parent.Root, bc.stateCache, bc.snaps)
+		if err != nil {
+			return it.index, err
 		}
 
 		bc.updateHighestVerifiedHeader(block.Header())

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2105,10 +2105,19 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 		if parent == nil {
 			parent = bc.GetHeader(block.ParentHash(), block.NumberU64()-1)
 		}
-		statedb, err := state.New(parent.Root, bc.stateCache, bc.snaps)
-		if err != nil {
-			return it.index, err
+		var statedb *state.StateDB
+		if ParallelTxMode {
+			statedb, err = state.NewBaseSlotDB(parent.Root, bc.stateCache, bc.snaps)
+			if err != nil {
+				return it.index, err
+			}
+		} else {
+			statedb, err = state.New(parent.Root, bc.stateCache, bc.snaps)
+			if err != nil {
+				return it.index, err
+			}
 		}
+
 		bc.updateHighestVerifiedHeader(block.Header())
 
 		// Enable prefetching to pull in trie node paths while processing transactions

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -145,7 +145,7 @@ func (ch createObjectChange) revert(s *StateDB) {
 	if s.parallel.isSlotDB {
 		delete(s.parallel.dirtiedStateObjectsInSlot, *ch.account)
 	} else {
-		s.stateObjects.Delete(*ch.account)
+		s.deleteStateObjectFromStateDB(*ch.account)
 	}
 	delete(s.stateObjectsDirty, *ch.account)
 }

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -942,7 +942,7 @@ func TestSuicide(t *testing.T) {
 	// Create an initial state with a few accounts
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
 	slotDb := NewSlotDB(state, systemAddress, 0, false)
 
 	addr := common.BytesToAddress([]byte("so"))
@@ -978,7 +978,7 @@ func TestSuicide(t *testing.T) {
 func TestSetAndGetState(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
 	slotDb := NewSlotDB(state, systemAddress, 0, false)
 
 	addr := common.BytesToAddress([]byte("so"))
@@ -1013,7 +1013,7 @@ func TestSetAndGetState(t *testing.T) {
 func TestSetAndGetCode(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
 	slotDb := NewSlotDB(state, systemAddress, 0, false)
 
 	addr := common.BytesToAddress([]byte("so"))
@@ -1046,7 +1046,7 @@ func TestSetAndGetCode(t *testing.T) {
 func TestGetCodeSize(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
 	slotDb := NewSlotDB(state, systemAddress, 0, false)
 
 	addr := common.BytesToAddress([]byte("so"))
@@ -1067,7 +1067,7 @@ func TestGetCodeSize(t *testing.T) {
 func TestGetCodeHash(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
 	slotDb := NewSlotDB(state, systemAddress, 0, false)
 
 	addr := common.BytesToAddress([]byte("so"))
@@ -1088,7 +1088,7 @@ func TestGetCodeHash(t *testing.T) {
 func TestSetNonce(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
 	slotDb := NewSlotDB(state, systemAddress, 0, false)
 
 	addr := common.BytesToAddress([]byte("so"))
@@ -1114,7 +1114,7 @@ func TestSetNonce(t *testing.T) {
 func TestSetAndGetBalance(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
 	slotDb := NewSlotDB(state, systemAddress, 0, true)
 
 	addr := systemAddress
@@ -1156,7 +1156,7 @@ func TestSetAndGetBalance(t *testing.T) {
 func TestSubBalance(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
 	slotDb := NewSlotDB(state, systemAddress, 0, true)
 
 	addr := systemAddress
@@ -1194,7 +1194,7 @@ func TestSubBalance(t *testing.T) {
 func TestAddBalance(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
 	slotDb := NewSlotDB(state, systemAddress, 0, true)
 
 	addr := systemAddress
@@ -1232,7 +1232,7 @@ func TestAddBalance(t *testing.T) {
 func TestEmpty(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
 	slotDb := NewSlotDB(state, systemAddress, 0, true)
 
 	addr := systemAddress
@@ -1251,7 +1251,7 @@ func TestEmpty(t *testing.T) {
 func TestExist(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
 	slotDb := NewSlotDB(state, systemAddress, 0, true)
 
 	addr := systemAddress
@@ -1270,7 +1270,7 @@ func TestExist(t *testing.T) {
 func TestMergeSlotDB(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db, nil)
+	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
 	oldSlotDb := NewSlotDB(state, systemAddress, 0, true)
 
 	newSlotDb := NewSlotDB(state, systemAddress, 0, true)

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -942,7 +942,9 @@ func TestSuicide(t *testing.T) {
 	// Create an initial state with a few accounts
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil)
+	state.PrepareForParallel()
+
 	slotDb := NewSlotDB(state, systemAddress, 0, false)
 
 	addr := common.BytesToAddress([]byte("so"))
@@ -978,7 +980,9 @@ func TestSuicide(t *testing.T) {
 func TestSetAndGetState(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil)
+	state.PrepareForParallel()
+
 	slotDb := NewSlotDB(state, systemAddress, 0, false)
 
 	addr := common.BytesToAddress([]byte("so"))
@@ -1013,7 +1017,9 @@ func TestSetAndGetState(t *testing.T) {
 func TestSetAndGetCode(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil)
+	state.PrepareForParallel()
+
 	slotDb := NewSlotDB(state, systemAddress, 0, false)
 
 	addr := common.BytesToAddress([]byte("so"))
@@ -1046,7 +1052,9 @@ func TestSetAndGetCode(t *testing.T) {
 func TestGetCodeSize(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil)
+	state.PrepareForParallel()
+
 	slotDb := NewSlotDB(state, systemAddress, 0, false)
 
 	addr := common.BytesToAddress([]byte("so"))
@@ -1067,7 +1075,9 @@ func TestGetCodeSize(t *testing.T) {
 func TestGetCodeHash(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil)
+	state.PrepareForParallel()
+
 	slotDb := NewSlotDB(state, systemAddress, 0, false)
 
 	addr := common.BytesToAddress([]byte("so"))
@@ -1088,7 +1098,9 @@ func TestGetCodeHash(t *testing.T) {
 func TestSetNonce(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil)
+	state.PrepareForParallel()
+
 	slotDb := NewSlotDB(state, systemAddress, 0, false)
 
 	addr := common.BytesToAddress([]byte("so"))
@@ -1114,7 +1126,9 @@ func TestSetNonce(t *testing.T) {
 func TestSetAndGetBalance(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil)
+	state.PrepareForParallel()
+
 	slotDb := NewSlotDB(state, systemAddress, 0, true)
 
 	addr := systemAddress
@@ -1156,7 +1170,9 @@ func TestSetAndGetBalance(t *testing.T) {
 func TestSubBalance(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil)
+	state.PrepareForParallel()
+
 	slotDb := NewSlotDB(state, systemAddress, 0, true)
 
 	addr := systemAddress
@@ -1194,7 +1210,9 @@ func TestSubBalance(t *testing.T) {
 func TestAddBalance(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil)
+	state.PrepareForParallel()
+
 	slotDb := NewSlotDB(state, systemAddress, 0, true)
 
 	addr := systemAddress
@@ -1232,7 +1250,9 @@ func TestAddBalance(t *testing.T) {
 func TestEmpty(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil)
+	state.PrepareForParallel()
+
 	slotDb := NewSlotDB(state, systemAddress, 0, true)
 
 	addr := systemAddress
@@ -1251,7 +1271,9 @@ func TestEmpty(t *testing.T) {
 func TestExist(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil)
+	state.PrepareForParallel()
+
 	slotDb := NewSlotDB(state, systemAddress, 0, true)
 
 	addr := systemAddress
@@ -1270,7 +1292,9 @@ func TestExist(t *testing.T) {
 func TestMergeSlotDB(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := NewBaseSlotDB(common.Hash{}, db, nil)
+	state, _ := New(common.Hash{}, db, nil)
+	state.PrepareForParallel()
+
 	oldSlotDb := NewSlotDB(state, systemAddress, 0, true)
 
 	newSlotDb := NewSlotDB(state, systemAddress, 0, true)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -869,13 +869,15 @@ func (p *StateProcessor) runSlotLoop(slotIndex int) {
 }
 
 // clear slot state for each block.
-func (p *StateProcessor) resetParallelState(txNum int) {
+func (p *StateProcessor) resetParallelState(txNum int, statedb *state.StateDB) {
 	if txNum == 0 {
 		return
 	}
 	p.mergedTxIndex = -1
 	p.debugErrorRedoNum = 0
 	p.debugConflictRedoNum = 0
+
+	statedb.PrepareForParallel()
 
 	for _, slot := range p.slotState {
 		slot.tailTxReq = nil
@@ -984,7 +986,7 @@ func (p *StateProcessor) ProcessParallel(block *types.Block, statedb *state.Stat
 	)
 	var receipts = make([]*types.Receipt, 0)
 	txNum := len(block.Transactions())
-	p.resetParallelState(txNum)
+	p.resetParallelState(txNum, statedb)
 
 	// Iterate over and process the individual transactions
 	posa, isPoSA := p.engine.(consensus.PoSA)


### PR DESCRIPTION
### Description

Use sync map for  for the stateObjects in used parallel and  no affect the stateObjects used in sequential process.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
